### PR TITLE
RTC 84990, Template correction for api version deprecation

### DIFF
--- a/template/ibm-powervc-csi-driver-template.yaml
+++ b/template/ibm-powervc-csi-driver-template.yaml
@@ -603,7 +603,7 @@ objects:
             hostPath:
               path: /usr/lib64/
               type: Directory
-- apiVersion: storage.k8s.io/v1beta1
+- apiVersion: storage.k8s.io/v1
   kind: CSIDriver
   metadata:
     name: ibm-powervc-csi


### PR DESCRIPTION
Changed apiVersion from v1beta1 to v1.
Changes have been verified in RTC 84990